### PR TITLE
Spotify track integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ riderModule.iml
 .idea/
 **/bin/
 **/obj/
+**/spotify-auth.json

--- a/src/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Extensions/HttpRequestMessageExtensions.cs
@@ -1,0 +1,23 @@
+namespace NoonGMT.CLI.Extensions;
+
+public static class HttpRequestMessageExtensions
+{
+    public static HttpRequestMessage AddBasicAuthorization(this HttpRequestMessage message, string token) =>
+        message.AddAuthHeader($"Basic {token}");
+
+    public static HttpRequestMessage AddBearerToken(this HttpRequestMessage message, string token) =>
+        message.AddAuthHeader($"Bearer {token}");
+
+    public static HttpRequestMessage AddFormUrlEncodedContent(this HttpRequestMessage message,
+        IEnumerable<KeyValuePair<string, string>> value)
+    {
+        message.Content = new FormUrlEncodedContent(value);
+        return message;
+    }
+
+    private static HttpRequestMessage AddAuthHeader(this HttpRequestMessage message, string value)
+    {
+        message.Headers.Add("Authorization", value);
+        return message;
+    }
+}

--- a/src/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NoonGMT.CLI.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static void AddNoonGMT(this IServiceCollection services, IConfigurationSection noonGmtOptions)
+    {
+        services.AddScoped<PostClient>();
+        services.AddScoped<PostService>();
+        services.Configure<NoonGmtOptions>(noonGmtOptions);
+    }
+}

--- a/src/Features/Spotify/AuthenticationInformation.cs
+++ b/src/Features/Spotify/AuthenticationInformation.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace NoonGMT.CLI.Features.Spotify;
+
+public class AuthenticationInformation
+{
+    [JsonPropertyName("access_token")]
+    public required string AccessToken { get; set; }
+    [JsonPropertyName("token_type")]
+    public required string TokenType { get; set; }
+    [JsonPropertyName("expires_in")]
+    public required int ExpiresIn { get; set; }
+    public DateTime Expires => DateTime.UtcNow.AddSeconds(ExpiresIn);
+}

--- a/src/Features/Spotify/AuthenticationInformation.cs
+++ b/src/Features/Spotify/AuthenticationInformation.cs
@@ -4,11 +4,19 @@ namespace NoonGMT.CLI.Features.Spotify;
 
 public class AuthenticationInformation
 {
+    [JsonIgnore]
+    private DateTime? _expires;
+
     [JsonPropertyName("access_token")]
     public required string AccessToken { get; set; }
     [JsonPropertyName("token_type")]
     public required string TokenType { get; set; }
     [JsonPropertyName("expires_in")]
     public required int ExpiresIn { get; set; }
-    public DateTime Expires => DateTime.UtcNow.AddSeconds(ExpiresIn);
+
+    public DateTime Expires
+    {
+        get => _expires ?? DateTime.UtcNow.AddSeconds(ExpiresIn);
+        set => _expires = value;
+    }
 }

--- a/src/Features/Spotify/AuthenticationOptions.cs
+++ b/src/Features/Spotify/AuthenticationOptions.cs
@@ -2,5 +2,5 @@ namespace NoonGMT.CLI.Features.Spotify;
 
 public class AuthenticationOptions
 {
-    public required string FilePath { get; set; }
+    public required string FilePath { get; set; } = "spotify-auth.json";
 }

--- a/src/Features/Spotify/AuthenticationOptions.cs
+++ b/src/Features/Spotify/AuthenticationOptions.cs
@@ -3,4 +3,5 @@ namespace NoonGMT.CLI.Features.Spotify;
 public class AuthenticationOptions
 {
     public required string FilePath { get; set; } = "spotify-auth.json";
+    public required int ExpiryThreshold { get; set; } = 600;
 }

--- a/src/Features/Spotify/AuthenticationOptions.cs
+++ b/src/Features/Spotify/AuthenticationOptions.cs
@@ -1,0 +1,6 @@
+namespace NoonGMT.CLI.Features.Spotify;
+
+public class AuthenticationOptions
+{
+    public required string FilePath { get; set; }
+}

--- a/src/Features/Spotify/AuthenticationService.cs
+++ b/src/Features/Spotify/AuthenticationService.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace NoonGMT.CLI.Features.Spotify;
+
+public class AuthenticationService(SpotifyClient client, IOptions<AuthenticationOptions> options)
+{
+    public async Task<string> GetBearerTokenAsync()
+    {
+        var filePath = options.Value.FilePath;
+        
+        // If a store already exists, try to use that first
+        if (File.Exists(filePath))
+        {
+            var store = await File.ReadAllTextAsync(filePath);
+            var auth = JsonSerializer.Deserialize<AuthenticationInformation>(store);
+            if (auth?.Expires >= DateTime.UtcNow)
+            {
+                return auth.AccessToken;
+            }
+        }
+
+        // Otherwise auth with the client and store to file
+        var response = await client.AuthenticateAsync();
+        await using var stream = File.Create(filePath);
+        await JsonSerializer.SerializeAsync(stream, response);
+        
+        return response.AccessToken;
+    }
+    
+}

--- a/src/Features/Spotify/AuthenticationService.cs
+++ b/src/Features/Spotify/AuthenticationService.cs
@@ -13,7 +13,7 @@ public class AuthenticationService(SpotifyClient client, IOptions<Authentication
         if (TryReadAllText(filePath, out var store))
         {
             var auth = JsonSerializer.Deserialize<AuthenticationInformation>(store);
-            if (auth?.Expires >= DateTime.UtcNow)
+            if (auth?.Expires >= DateTime.UtcNow.AddSeconds(options.Value.ExpiryThreshold))
             {
                 return auth.AccessToken;
             }

--- a/src/Features/Spotify/AuthenticationService.cs
+++ b/src/Features/Spotify/AuthenticationService.cs
@@ -21,6 +21,11 @@ public class AuthenticationService(SpotifyClient client, IOptions<Authentication
 
         // Otherwise auth with the client and store to file
         var response = await client.AuthenticateAsync();
+        if (response is null)
+        {
+            throw new InvalidOperationException("Unable to obtain bearer token from Spotify.");
+        }
+        
         await using var stream = File.Create(filePath);
         await JsonSerializer.SerializeAsync(stream, response);
         

--- a/src/Features/Spotify/AuthenticationService.cs
+++ b/src/Features/Spotify/AuthenticationService.cs
@@ -10,9 +10,8 @@ public class AuthenticationService(SpotifyClient client, IOptions<Authentication
         var filePath = options.Value.FilePath;
         
         // If a store already exists, try to use that first
-        if (File.Exists(filePath))
+        if (TryReadAllText(filePath, out var store))
         {
-            var store = await File.ReadAllTextAsync(filePath);
             var auth = JsonSerializer.Deserialize<AuthenticationInformation>(store);
             if (auth?.Expires >= DateTime.UtcNow)
             {
@@ -27,5 +26,16 @@ public class AuthenticationService(SpotifyClient client, IOptions<Authentication
         
         return response.AccessToken;
     }
-    
+
+    private static bool TryReadAllText(string filePath, out string text)
+    {
+        if (!File.Exists(filePath))
+        {
+            text = string.Empty;
+            return false;
+        }
+
+        text = File.ReadAllText(filePath);
+        return true;
+    }
 }

--- a/src/Features/Spotify/ServiceCollectionExtensions.cs
+++ b/src/Features/Spotify/ServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NoonGMT.CLI.Features.Spotify;
+
+public static class ServiceCollectionExtensions
+{
+    public static void AddSpotify(this IServiceCollection services, IConfigurationSection spotifyOptions, IConfigurationSection authenticationOptions)
+    {
+        services.Configure<SpotifyOptions>(spotifyOptions);
+        services.Configure<AuthenticationOptions>(authenticationOptions);
+        services.AddScoped<SpotifyClient>();
+        services.AddScoped<AuthenticationService>();
+        services.AddScoped<SpotifyService>();
+    }
+}

--- a/src/Features/Spotify/SpotifyClient.cs
+++ b/src/Features/Spotify/SpotifyClient.cs
@@ -1,0 +1,54 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Options;
+using NoonGMT.CLI.Extensions;
+
+namespace NoonGMT.CLI.Features.Spotify;
+
+public class SpotifyClient
+{
+    private readonly HttpClient _client;
+    private readonly IOptions<SpotifyOptions> _options;
+
+    public SpotifyClient(IOptions<SpotifyOptions> options)
+    {
+        _options = options;
+        _client = new();
+    }
+
+    public async Task<AuthenticationInformation> AuthenticateAsync()
+    {
+        var basicToken = Base64Encode($"{_options.Value.ClientId}:{_options.Value.ClientSecret}");
+        var url = _options.Value.AuthenticationEndpoint;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+            .AddBasicAuthorization(basicToken)
+            .AddFormUrlEncodedContent(new KeyValuePair<string, string>[]
+            {
+                new("grant_type", "client_credentials")
+            });
+
+        var response = await _client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<AuthenticationInformation>();
+    }
+
+    public async Task<TrackInformation> GetTrackInformationAsync(string bearerToken, string trackId)
+    {
+        var url = $"{_options.Value.TrackInformationEndpoint}/{trackId}";
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url)
+            .AddBearerToken(bearerToken);
+
+        var response = await _client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<TrackInformation>();
+    }
+
+    private static string Base64Encode(string value)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(value);
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/src/Features/Spotify/SpotifyOptions.cs
+++ b/src/Features/Spotify/SpotifyOptions.cs
@@ -1,0 +1,9 @@
+namespace NoonGMT.CLI.Features.Spotify;
+
+public class SpotifyOptions
+{
+    public required string ClientId { get; set; }
+    public required string ClientSecret { get; set; }
+    public required string AuthenticationEndpoint { get; set; }
+    public required string TrackInformationEndpoint { get; set; }
+}

--- a/src/Features/Spotify/SpotifyService.cs
+++ b/src/Features/Spotify/SpotifyService.cs
@@ -1,0 +1,20 @@
+namespace NoonGMT.CLI.Features.Spotify;
+
+public class SpotifyService
+{
+    private readonly AuthenticationService _authService;
+    private readonly SpotifyClient _spotifyClient;
+
+    public SpotifyService(AuthenticationService authService, SpotifyClient spotifyClient)
+    {
+        _authService = authService;
+        _spotifyClient = spotifyClient;
+    }
+
+    public async Task<string> GetTrackSummaryAsync(string trackId)
+    {
+        var bearerToken = await _authService.GetBearerTokenAsync();
+        var response = await _spotifyClient.GetTrackInformationAsync(bearerToken, trackId);
+        return response.ToString();
+    }
+}

--- a/src/Features/Spotify/SpotifyService.cs
+++ b/src/Features/Spotify/SpotifyService.cs
@@ -1,20 +1,13 @@
 namespace NoonGMT.CLI.Features.Spotify;
 
-public class SpotifyService
+public class SpotifyService(AuthenticationService authService, SpotifyClient spotifyClient)
 {
-    private readonly AuthenticationService _authService;
-    private readonly SpotifyClient _spotifyClient;
-
-    public SpotifyService(AuthenticationService authService, SpotifyClient spotifyClient)
+    private string? BearerToken { get; set; }
+    
+    public async Task<string?> GetTrackSummaryAsync(string trackId)
     {
-        _authService = authService;
-        _spotifyClient = spotifyClient;
-    }
-
-    public async Task<string> GetTrackSummaryAsync(string trackId)
-    {
-        var bearerToken = await _authService.GetBearerTokenAsync();
-        var response = await _spotifyClient.GetTrackInformationAsync(bearerToken, trackId);
-        return response.ToString();
+        var bearerToken = BearerToken ??= await authService.GetBearerTokenAsync();
+        var response = await spotifyClient.GetTrackInformationAsync(bearerToken, trackId);
+        return response?.ToString();
     }
 }

--- a/src/Features/Spotify/TrackInformation.cs
+++ b/src/Features/Spotify/TrackInformation.cs
@@ -1,0 +1,18 @@
+namespace NoonGMT.CLI.Features.Spotify;
+
+public class TrackInformation
+{
+    public Artist[] Artists { get; set; } = Array.Empty<Artist>();
+    public string? Name { get; set; }
+
+    public override string ToString()
+    {
+        var artists = string.Join(", ", Artists.Select(x => x.Name));
+        return $"{artists} - {Name}";
+    }
+}
+
+public class Artist
+{
+    public string? Name { get; set; }
+}

--- a/src/Models/Post.cs
+++ b/src/Models/Post.cs
@@ -42,7 +42,7 @@ public class Post
             builder.Append($"Id: {Id}, ");
         }
 
-        builder.Append($"Track: {TrackSummary ?? TrackId}, Description: {Description}");
+        builder.Append($"Track: {TrackSummary ?? TrackId}, Description: {Description ?? "None"}");
 
         return builder.ToString();
     }

--- a/src/Models/Post.cs
+++ b/src/Models/Post.cs
@@ -13,7 +13,8 @@ public class Post
     public string? Id { get; set; }
 
     [JsonPropertyName("track_id")]
-    public required string TrackId { get; set; }
+    public string? TrackId { get; set; }
+    public string? TrackSummary { get; set; }
     public string? Description { get; set; }
 
     [JsonPropertyName("live_date")]
@@ -41,7 +42,7 @@ public class Post
             builder.Append($"Id: {Id}, ");
         }
 
-        builder.Append($"Track: {TrackId}, Description: {Description}");
+        builder.Append($"Track: {TrackSummary ?? TrackId}, Description: {Description}");
 
         return builder.ToString();
     }

--- a/src/Models/Post.cs
+++ b/src/Models/Post.cs
@@ -13,7 +13,7 @@ public class Post
     public string? Id { get; set; }
 
     [JsonPropertyName("track_id")]
-    public string TrackId { get; set; } = null!;
+    public required string TrackId { get; set; }
     public string? Description { get; set; }
 
     [JsonPropertyName("live_date")]

--- a/src/Models/Result.cs
+++ b/src/Models/Result.cs
@@ -1,0 +1,28 @@
+namespace NoonGMT.CLI.Models;
+
+public class Result<T>
+{
+    public Result() { }
+
+    public Result(string error)
+    {
+        Success = false;
+        Errors = new []{ error };
+    }
+    
+    public Result(IEnumerable<string> errors)
+    {
+        Success = false;
+        Errors = errors;
+    }
+
+    public Result(T? value)
+    {
+        Success = true;
+        Value = value;
+    }
+
+    public bool Success { get; set; }
+    public T? Value { get; set; }
+    public IEnumerable<string>? Errors { get; set; } = Array.Empty<string>();
+}

--- a/src/PostService.cs
+++ b/src/PostService.cs
@@ -1,0 +1,109 @@
+using NoonGMT.CLI.Extensions;
+using NoonGMT.CLI.Features.Spotify;
+using NoonGMT.CLI.Models;
+
+namespace NoonGMT.CLI;
+
+public class PostService(PostClient client, SpotifyService spotifyService)
+{
+    public async Task<Post[]> GetAllAsync(int size, bool liveOnly)
+    {
+        var results = await client.GetAllAsync(size, liveOnly);
+
+        foreach (var post in results)
+        {
+            post.TrackSummary = await spotifyService.GetTrackSummaryAsync(post.TrackId);
+        }
+
+        return results;
+    }
+
+    public async Task<Result<Post>> AddAsync(DateTime? goLiveDate, string track, string? description, bool force = false)
+    {
+        var date = goLiveDate?.ToNoonLocalInUTC() ?? await client.GetNextAvailableDateAsync();
+        
+        // We only need to check the date is free if its provided
+        if (goLiveDate is not null)
+        {
+            var existingPost = await client.GetAsync(date);
+            if (existingPost is not null)
+            {
+                return new Result<Post>(new[]
+                    { "Post already exists for this date. Original post:", existingPost.ToString(true) });
+            }
+        }
+
+        var trackId = track.GetTrackId();
+        var duplicate = await client.GetByTrackIdAsync(trackId);
+        if (duplicate is not null && !force)
+        {
+            return new Result<Post>(new[]
+                { "Track has already been submitted. Original post:", duplicate.ToString(true) });
+        }
+        
+        var post = new Post
+        {
+            LiveDate = date,
+            TrackId = trackId,
+            Description = description
+        };
+
+        var response = await client.AddAsync(post);
+
+        return new Result<Post>(response!);
+    }
+
+    public async Task<Result<Post>> UpdateAsync(string? id, DateTime? date, string? description, string? track,
+        bool force = false)
+    {
+        if (string.IsNullOrWhiteSpace(id) && date is null)
+        {
+            return new Result<Post>("Id or Date need to be provided.");
+        }
+        
+        var existingPost = !string.IsNullOrWhiteSpace(id)
+            ? await client.GetAsync(id)
+            : await client.GetAsync(date!.Value);
+
+        if (existingPost is null)
+        {
+            return new Result<Post>("Id or Date need to be provided.");
+        }
+        
+        var trackId = track?.GetTrackId();
+        if (trackId is not null)
+        {
+            var duplicate = await client.GetByTrackIdAsync(trackId);
+            if (duplicate is not null && !force)
+            {
+                return new Result<Post>(new[]
+                    { "Track has already been submitted. Original post:", duplicate.ToString(true) });
+            }
+        }
+        
+        existingPost.TrackId = trackId ?? existingPost.TrackId;
+        existingPost.Description = description ?? existingPost.Description;
+
+        var result = await client.UpdateAsync(existingPost.Id!, existingPost);
+
+        return new Result<Post>(result!);
+    }
+
+    public async Task<Result<Post>> GetAsync(string? id, DateTime? date)
+    {
+        if (string.IsNullOrWhiteSpace(id) && date is null)
+        {
+            return new Result<Post>("Id or Date need to be provided.");
+        }
+
+        var result = !string.IsNullOrWhiteSpace(id)
+            ? await client.GetAsync(id)
+            : await client.GetAsync(date!.Value);
+
+        return new Result<Post>(result);
+    }
+
+    public Task<int> CountAsync() => client.CountAsync();
+
+    public Task<(int queued, DateTime? next)> GetQueueAsync() => client.GetQueueAsync();
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,14 +1,12 @@
 ﻿using System.Text;
-using Microsoft.Extensions.DependencyInjection;
 using Cocona;
 using NoonGMT.CLI;
+using NoonGMT.CLI.Extensions;
 using NoonGMT.CLI.Features.Spotify;
 
 var builder = CoconaApp.CreateBuilder(null, opt => { opt.EnableShellCompletionSupport = true; });
 
-builder.Services.AddScoped<PostClient>();
-builder.Services.AddScoped<PostService>();
-builder.Services.Configure<NoonGmtOptions>(builder.Configuration.GetSection(nameof(NoonGmtOptions)));
+builder.Services.AddNoonGMT(builder.Configuration.GetSection(nameof(NoonGmtOptions)));
 builder.Services.AddSpotify(
     builder.Configuration.GetSection(nameof(SpotifyOptions)),
     builder.Configuration.GetSection(nameof(AuthenticationOptions)));

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -15,12 +15,6 @@ builder.Services.AddSpotify(
 
 var app = builder.Build();
 
-app.AddCommand(async ([FromService] SpotifyService service) =>
-{
-    var track = await service.GetTrackSummaryAsync("34UANp5qxDg6YcgrlDeILZ");
-    Console.WriteLine(track);
-});
-
 app.AddCommand("list",
 async ([FromService] PostService service, 
     [Option('s', Description = "The number of returned items.")] int size = 5, 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -3,12 +3,16 @@ using Microsoft.Extensions.DependencyInjection;
 using Cocona;
 using NoonGMT.CLI;
 using NoonGMT.CLI.Extensions;
+using NoonGMT.CLI.Features.Spotify;
 using NoonGMT.CLI.Models;
 
 var builder = CoconaApp.CreateBuilder(null, opt => { opt.EnableShellCompletionSupport = true; });
 
 builder.Services.AddScoped<PostClient>();
 builder.Services.Configure<NoonGmtOptions>(builder.Configuration.GetSection(nameof(NoonGmtOptions)));
+builder.Services.AddSpotify(
+    builder.Configuration.GetSection(nameof(SpotifyOptions)),
+    builder.Configuration.GetSection(nameof(AuthenticationOptions)));
 
 var app = builder.Build();
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -45,12 +45,7 @@ app.AddCommand("add",
         var result = await service.AddAsync(goLiveDate, track, description, force);
         if (!result.Success)
         {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine("ERROR!");
-            foreach (var error in result.Errors)
-            {
-                Console.WriteLine(error);
-            }
+            WriteErrors(result.Errors!);
             return;
         }
 
@@ -69,12 +64,7 @@ app.AddCommand("update",
         var result = await service.UpdateAsync(id, date, description, track, force);
         if (!result.Success)
         {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine("ERROR!");
-            foreach (var error in result.Errors)
-            {
-                Console.WriteLine(error);
-            }
+            WriteErrors(result.Errors!);
             return;
         }
 
@@ -90,12 +80,7 @@ app.AddCommand("get",
     var result = await service.GetAsync(id, date);
     if (!result.Success)
     {
-        Console.ForegroundColor = ConsoleColor.Red;
-        Console.WriteLine("ERROR!");
-        foreach (var error in result.Errors)
-        {
-            Console.WriteLine(error);
-        }
+        WriteErrors(result.Errors!);
         return;
     }
     
@@ -135,3 +120,14 @@ app.AddCommand("queue", async ([FromService] PostService service) =>
 });
 
 app.Run();
+return;
+
+void WriteErrors(IEnumerable<string> errors)
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.WriteLine("ERROR!");
+    foreach (var error in errors)
+    {
+        Console.WriteLine(error);
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -125,6 +125,11 @@ return;
 void WriteErrors(IEnumerable<string> errors)
 {
     Console.ForegroundColor = ConsoleColor.Red;
+    if (!errors.Any())
+    {
+        Console.WriteLine("Failed but no error message provided!");
+    }
+    
     foreach (var error in errors)
     {
         Console.WriteLine(error);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -22,60 +22,60 @@ app.AddCommand(async ([FromService] SpotifyService service) =>
 });
 
 app.AddCommand("list",
-    async ([FromService] PostService service, 
-        [Option('s', Description = "The number of returned items.")] int size = 5, 
-        [Option(Description = "Whether to show live and future posts.")] bool liveOnly = false, 
-        [Option(Description = "Whether to include the IDs of the posts.")] bool includeIds = false,
-        [Option(Description = "Whether to include the time the post goes live, along with the date.")] bool includeTime = false) =>
+async ([FromService] PostService service, 
+    [Option('s', Description = "The number of returned items.")] int size = 5, 
+    [Option(Description = "Whether to show live and future posts.")] bool liveOnly = false, 
+    [Option(Description = "Whether to include the IDs of the posts.")] bool includeIds = false,
+    [Option(Description = "Whether to include the time the post goes live, along with the date.")] bool includeTime = false) =>
+{
+    var results = await service.GetAllAsync(size, liveOnly);
+    foreach (var post in results.OrderByDescending(x => x.LiveDate))
     {
-        var results = await service.GetAllAsync(size, liveOnly);
-        foreach (var post in results.OrderByDescending(x => x.LiveDate))
-        {
-            Console.WriteLine(post.ToString(includeIds, includeTime));
-        }
-    });
+        Console.WriteLine(post.ToString(includeIds, includeTime));
+    }
+});
 
 app.AddCommand("add",
-    async ([FromService] PostService service,
-        [Option('l', Description = "The date the post goes live.")] DateTime? goLiveDate,
-        [Option('i', Description = "The ID or share link of the Spotify track.")] string track,
-        [Option('d', Description = "An optional description.")] string? description,
-        [Option(Description = "Force submit the post, even if a duplicate has been found.")] bool force = false) =>
+async ([FromService] PostService service,
+    [Option('l', Description = "The date the post goes live.")] DateTime? goLiveDate,
+    [Option('i', Description = "The ID or share link of the Spotify track.")] string track,
+    [Option('d', Description = "An optional description.")] string? description,
+    [Option(Description = "Force submit the post, even if a duplicate has been found.")] bool force = false) =>
+{
+    var result = await service.AddAsync(goLiveDate, track, description, force);
+    if (!result.Success)
     {
-        var result = await service.AddAsync(goLiveDate, track, description, force);
-        if (!result.Success)
-        {
-            WriteErrors(result.Errors!);
-            return;
-        }
+        WriteErrors(result.Errors!);
+        return;
+    }
 
-        Console.WriteLine("Success! New Post:");
-        Console.WriteLine(result.Value!.ToString(true, true));
-    });
+    Console.WriteLine("Success! New Post:");
+    Console.WriteLine(result.Value!.ToString(true, true));
+});
 
 app.AddCommand("update",
-    async ([FromService] PostService service, 
-        [Option(Description = "The id of the post.")] string? id, 
-        [Option(Description = "The go live date of the post.")] DateTime? date, 
-        [Option('d', Description = "The replacement post description.")] string? description,
-        [Option('i', Description = "The replacement track.")] string? track,
-        [Option(Description = "Force submit the post, even if a duplicate has been found.")] bool force = false) =>
+async ([FromService] PostService service, 
+    [Option(Description = "The id of the post.")] string? id, 
+    [Option(Description = "The go live date of the post.")] DateTime? date, 
+    [Option('d', Description = "The replacement post description.")] string? description,
+    [Option('i', Description = "The replacement track.")] string? track,
+    [Option(Description = "Force submit the post, even if a duplicate has been found.")] bool force = false) =>
+{
+    var result = await service.UpdateAsync(id, date, description, track, force);
+    if (!result.Success)
     {
-        var result = await service.UpdateAsync(id, date, description, track, force);
-        if (!result.Success)
-        {
-            WriteErrors(result.Errors!);
-            return;
-        }
+        WriteErrors(result.Errors!);
+        return;
+    }
 
-        Console.WriteLine("Success! Updated post:");
-        Console.WriteLine(result.Value!.ToString());
-    });
+    Console.WriteLine("Success! Updated post:");
+    Console.WriteLine(result.Value!.ToString());
+});
 
 app.AddCommand("get", 
-    async ([FromService] PostService service, 
-        [Option(Description = "The id of the post.")] string? id, 
-        [Option(Description = "The date of the post.")] DateTime? date) =>
+async ([FromService] PostService service, 
+    [Option(Description = "The id of the post.")] string? id, 
+    [Option(Description = "The date of the post.")] DateTime? date) =>
 {
     var result = await service.GetAsync(id, date);
     if (!result.Success)
@@ -128,6 +128,7 @@ void WriteErrors(IEnumerable<string> errors)
     if (!errors.Any())
     {
         Console.WriteLine("Failed but no error message provided!");
+        return;
     }
     
     foreach (var error in errors)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -23,7 +23,7 @@ async ([FromService] PostService service,
     [Option(Description = "Whether to include the time the post goes live, along with the date.")] bool includeTime = false) =>
 {
     var results = await service.GetAllAsync(size, liveOnly);
-    foreach (var post in results.OrderByDescending(x => x.LiveDate))
+    await foreach (var post in results)
     {
         Console.WriteLine(post.ToString(includeIds, includeTime));
     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -125,7 +125,6 @@ return;
 void WriteErrors(IEnumerable<string> errors)
 {
     Console.ForegroundColor = ConsoleColor.Red;
-    Console.WriteLine("ERROR!");
     foreach (var error in errors)
     {
         Console.WriteLine(error);

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -5,7 +5,16 @@
     }
   },
   "NoonGmtOptions": {
-    "BaseUrl": "http://localhost:8090",
-    "ApiKey": "placeholder"
+    "BaseUrl": "http://localhost",
+    "ApiKey": "thisisthekey"
+  },
+  "SpotifyOptions": {
+    "AuthenticationEndpoint": "https://accounts.spotify.com/api/token",
+    "TrackInformationEndpoint": "https://api.spotify.com/v1/tracks",
+    "ClientId": "placeholder",
+    "ClientSecret": "placeholder"
+  },
+  "AuthenticationOptions": {
+    "FilePath": "spotify-auth.json"
   }
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -16,5 +16,7 @@
   },
   "AuthenticationOptions": {
     "FilePath": "spotify-auth.json"
+    "FilePath": "spotify-auth.json",
+    "ExpiryThreshold": 300
   }
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -15,7 +15,6 @@
     "ClientSecret": "placeholder"
   },
   "AuthenticationOptions": {
-    "FilePath": "spotify-auth.json"
     "FilePath": "spotify-auth.json",
     "ExpiryThreshold": 300
   }


### PR DESCRIPTION
### Add support for displaying track information obtaining from Spotify.
- Outputs will now include track information (artists, track name) rather than just the track id
- Add support for storing auth information in a JSON file in the root folder.
- If the stored auth information is invalid, automatically reauth before requesting track information.

TODO: 
- Cache track titles against their ids so we only have to query Spotify the first time