### PR TITLE
get-improvements

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -67,8 +67,12 @@ async ([FromService] PostService service,
 app.AddCommand("get", 
 async ([FromService] PostService service, 
     [Option(Description = "The id of the post.")] string? id, 
-    [Option(Description = "The date of the post.")] DateTime? date) =>
+    [Option(Description = "The date of the post.")] DateTime? date,
+    [Option(Description = "Get the next post to release.")] bool next = false) =>
 {
+    // If no date is provided, or next is and its before 12, show todays release
+    date ??= next && DateTime.UtcNow.Hour >= 12 ? DateTime.UtcNow.AddDays(1) : DateTime.UtcNow;
+    
     var result = await service.GetAsync(id, date);
     if (!result.Success)
     {


### PR DESCRIPTION
Improve the get command with the following:

- Providing no date or id will default to todays release
- Providing the `--next` flag will display the next release. If this is called before noon it will be the release of the day, otherwise it will return the following days release