### PR TITLE
no-spotify-auth

### DIFF
--- a/src/Features/Spotify/AuthenticationService.cs
+++ b/src/Features/Spotify/AuthenticationService.cs
@@ -5,7 +5,7 @@ namespace NoonGMT.CLI.Features.Spotify;
 
 public class AuthenticationService(SpotifyClient client, IOptions<AuthenticationOptions> options)
 {
-    public async Task<string> GetBearerTokenAsync()
+    public async Task<string?> GetBearerTokenAsync()
     {
         var filePath = options.Value.FilePath;
         
@@ -23,7 +23,8 @@ public class AuthenticationService(SpotifyClient client, IOptions<Authentication
         var response = await client.AuthenticateAsync();
         if (response is null)
         {
-            throw new InvalidOperationException("Unable to obtain bearer token from Spotify.");
+            // If no auth was obtained, exit here
+            return null;
         }
         
         await using var stream = File.Create(filePath);

--- a/src/Features/Spotify/SpotifyService.cs
+++ b/src/Features/Spotify/SpotifyService.cs
@@ -7,6 +7,12 @@ public class SpotifyService(AuthenticationService authService, SpotifyClient spo
     public async Task<string?> GetTrackSummaryAsync(string trackId)
     {
         var bearerToken = BearerToken ??= await authService.GetBearerTokenAsync();
+        if (bearerToken is null)
+        {
+            // No bearer token means we can't obtain track information.
+            return trackId;
+        }
+
         var response = await spotifyClient.GetTrackInformationAsync(bearerToken, trackId);
         return response?.ToString();
     }


### PR DESCRIPTION
Spotify Auth should not be a requirement for using the application. In the instance that auth is unable to be obtained (either because it was not provided or failed) continue just using trackId.